### PR TITLE
Fix broken slack URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
       <ul class="social-list">
         {% if site.slack_username %}
         <li>
-          <i class="fa fa-slack"></i> <a href="{{ site.slack_username }}.slack.com">{{ site.slack_username }}</a>
+          <i class="fa fa-slack"></i> <a href="https://{{ site.slack_username }}.slack.com">{{ site.slack_username }}</a>
         </li>
         {% endif %}
 


### PR DESCRIPTION
The link to the slack was broken. It was relative to the current address (hackerspaceblumenai.github.io)
